### PR TITLE
Added high "Content Download" time

### DIFF
--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -139,7 +139,7 @@ When using the web server tuning settings in 64-bit, the limits will only exist 
 
 ### Description
 
-In OutSystems on-premise installations, some Windows Server operations are either slow to execute, with CPU usage reaching peaks, or with a high ["Content Download"](https://developers.google.com/web/tools/chrome-devtools/network/reference#timing-explanation) time when loading pages. You should minimize the system performance impact of your antivirus software.
+In OutSystems on-premises installations, some Windows Server operations are either slow to execute, with CPU usage reaching peaks, or have a high ["Content Download"](https://developers.google.com/web/tools/chrome-devtools/network/reference#timing-explanation) time when loading pages. You should minimize the system performance impact of your antivirus software.
 
 ### Solution
 

--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -139,7 +139,7 @@ When using the web server tuning settings in 64-bit, the limits will only exist 
 
 ### Description
 
-Some Windows Server operations are slow to execute, with CPU usage reaching peaks, in OutSystems on-premise installations. You should minimize the system performance impact of your antivirus software.
+In OutSystems on-premise installations, some Windows Server operations are either slow to execute, with CPU usage reaching peaks, or with a high ["Content Download"](https://developers.google.com/web/tools/chrome-devtools/network/reference#timing-explanation) time when loading pages. You should minimize the system performance impact of your antivirus software.
 
 ### Solution
 


### PR DESCRIPTION
Added high "Content Download" time, which is a slowness symptom that can be caused by an anti-virus when loading pages. This was observed by a customer in the ticket #2426792.