### PR TITLE
Add temp folder of OSControllerUser to antivirus exclusion list

### DIFF
--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -151,6 +151,8 @@ If Windows Defender is active, or any other antivirus protection, disable the re
 
 * `.NET` Framework configuration files in `%WINDIR%\Microsoft.Net\framework64\v<version>\Config` (on a 64-bit system)
 
+* Temporary folder of OSControllerUser, used to publish (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
+
 * Optionally, the system temporary folder (typically `%TEMP%` or `C:\Windows\Temp`).
 
 ### Importance

--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -151,7 +151,7 @@ If Windows Defender is active, or any other antivirus protection, disable the re
 
 * `.NET` Framework configuration files in `%WINDIR%\Microsoft.Net\framework64\v<version>\Config` (on a 64-bit system)
 
-* Temporary folder of OSControllerUser, used for publishing (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
+* Temporary folder of the user used to run the OutSystems Deployment Controller Service. That can either be Windows Authentication user used for the Database or OSControllerUser (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
 
 * Optionally, the system temporary folder (typically `%TEMP%` or `C:\Windows\Temp`).
 

--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -151,7 +151,7 @@ If Windows Defender is active, or any other antivirus protection, disable the re
 
 * `.NET` Framework configuration files in `%WINDIR%\Microsoft.Net\framework64\v<version>\Config` (on a 64-bit system)
 
-* Temporary folder of OSControllerUser, used to publish (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
+* Temporary folder of OSControllerUser, used for publishing (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
 
 * Optionally, the system temporary folder (typically `%TEMP%` or `C:\Windows\Temp`).
 


### PR DESCRIPTION
Add Temp folder of OSControllerUser to antivirus exclusion list.
This folder is used for publishing.