### PR TITLE
Improve "Exclude some folders from antivirus scanning"

### DIFF
--- a/src/performance/infrastructure/infrastructure.md
+++ b/src/performance/infrastructure/infrastructure.md
@@ -151,13 +151,13 @@ If Windows Defender is active, or any other antivirus protection, disable the re
 
 * OutSystems Platform Server installation folder (the default is `C:\Program Files\OutSystems\Platform Server\`)
 
-* Temporary `ASP.NET` files location in `%WINDIR%\Microsoft.Net\framework64\v<version>\TemporaryASP.NET` Files (on a 64-bit system)
+* Temporary ASP.NET files location in `%WINDIR%\Microsoft.Net\Framework64\v4.0.30319\Temporary ASP.NET Files` (the default on a 64-bit system)
 
-* `.NET` Framework configuration files in `%WINDIR%\Microsoft.Net\framework64\v<version>\Config` (on a 64-bit system)
+* .NET Framework configuration files in `%WINDIR%\Microsoft.Net\Framework64\v4.0.30319\Config` (on a 64-bit system)
 
-* Temporary folder of the user used to run the OutSystems Deployment Controller Service. That can either be Windows Authentication user used for the Database or OSControllerUser (typically `C:\Users\OSControllerUser\AppData\Local\Temp`)
+* Temporary folder of the user account used to run the OutSystems Deployment Controller Service. This can either be the Windows Authentication account configured for Administrator access to the Platform database or a specific account depending on the Platform Server version installed, which be be determined in the [Default Platform Server and database configurations](https://success.outsystems.com/documentation/11/setup_and_maintain_your_outsystems_infrastructure/setting_up_outsystems/default_platform_server_and_database_configurations/#services) (typically `C:\Users\OutSystems Deployment Controller Service\AppData\Local\Temp`)
 
-* Optionally, the system temporary folder (typically `%TEMP%` or `C:\Windows\Temp`).
+* Optionally, the system temporary folder (typically `C:\Windows\Temp`).
 
 ### Importance
 


### PR DESCRIPTION
- Missing space in the "Temporary ASP.NET" path
- Removed formatting from ASP.NET and .NET
- .NET Framework version in path is always 4.0.30319 in what is relevant to OutSystems 10 and 11, use of version unnecessary?
- Case correction of \framework64\ to \Framework64\
- `Temporary ASP.NET` Files -> `Temporary ASP.NET Files`
- Improve details about the account used to run the Deployment Controller Service, include link to documentation about accounts used in different Platform versions, and update example with the account in the latest versions
- Add that the Temporary ASP.NET location mentioned is the default (it can be changed and it's common to do it).
- Remove the reference to %TEMP% because as a system variable it points to C:\Windows\Temp but as a user variable it usually points to %USERPROFILE%\AppData\Local\Temp, so if a user (running under a standard user account) checks the location of %TEMP% they would get %USERPROFILE%\AppData\Local\Temp