### PR TITLE
Update archive.md

### DIFF
--- a/src/architecture/data/archive.md
+++ b/src/architecture/data/archive.md
@@ -81,7 +81,7 @@ Mirror the data source modules in the **archive catalog** side, in a way simple 
 
 * Copy entities only.
 
-* Set the **Is AutoNumber** property to `No` for IDs, Indexes, and the IsArchived attribute.
+* Set the **Is AutoNumber** property to `No` for all possible attributes.
 
 * Set the **Delete Rule** property of foreign keys to `Ignore`.
 


### PR DESCRIPTION
Since it's possible to have only one attribute with "IsAutonumber" set to 'yes', and also only integer/long integer data types can have this options active, it makes no sense to inform on the documentation to disable the autonumbering for indexes and other data types such as Boolean.